### PR TITLE
fix(test): fix unit test with date in GMT+02:00 time zone

### DIFF
--- a/dataformat-xml-dom/pom.xml
+++ b/dataformat-xml-dom/pom.xml
@@ -76,7 +76,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.17</version>
             <configuration>
-              <argLine>-XX:PermSize=128m -XX:MaxPermSize=256m</argLine>
+              <argLine>-XX:PermSize=128m -XX:MaxPermSize=256m -Duser.timezone=GMT+02:00</argLine>
               <excludes>
                 <exclude>**/javascript/**</exclude>
               </excludes>


### PR DESCRIPTION
In unit tests validation date string uses time zone pattern: 
 -- 2015-04-04T00:00:00+02:00
Add -Duser.timezone=GMT+02:00 attribute to maven-surefire-plugin 
in order to set default time zone during tests execution. 
This avoids tests to be failed because of different time zones.

related to #CAM-4012