### PR TITLE
chore(xpath): throw exception for non existing elements, attributes

### DIFF
--- a/core/src/main/java/org/camunda/spin/impl/logging/SpinCoreLogger.java
+++ b/core/src/main/java/org/camunda/spin/impl/logging/SpinCoreLogger.java
@@ -22,8 +22,6 @@ import org.camunda.spin.spi.DataFormat;
 import org.camunda.spin.spi.DataFormatConfigurator;
 import org.camunda.spin.spi.DataFormatProvider;
 import org.camunda.spin.spi.SpinDataFormatException;
-import org.camunda.spin.xml.SpinXmlElement;
-import org.camunda.spin.xml.SpinXmlElementException;
 
 
 /**
@@ -53,14 +51,6 @@ public class SpinCoreLogger extends SpinLogger {
 
   public SpinDataFormatException unrecognizableDataFormatException() {
     return new SpinDataFormatException(exceptionMessage("004", "No matching data format detected"));
-  }
-
-  public SpinXmlElementException elementIsNotChildOfThisElement(SpinXmlElement existingChildElement, SpinXmlElement parentDomElement) {
-    return new SpinXmlElementException(exceptionMessage("005", "The element with namespace '{}' and name '{}' " +
-        "is not a child element of the element with namespace '{}' and name '{}'",
-      existingChildElement.namespace(), existingChildElement.name(),
-      parentDomElement.namespace(), parentDomElement.name()
-    ));
   }
 
   public SpinScriptException noScriptEnvFoundForLanguage(String scriptLanguage, String path) {

--- a/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/DomXmlLogger.java
+++ b/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/DomXmlLogger.java
@@ -168,8 +168,20 @@ public class DomXmlLogger extends SpinLogger {
     return new SpinXmlDataFormatException(exceptionMessage("033", "Cannot set property '{}' to '{}'", propertyName, className), cause);
   }
 
-  public SpinXmlElementException unableToFindElementWithXPathExpression(String expression) {
-    return new SpinXmlElementException(exceptionMessage("034", "Unable to find element with XPath expression '{}'", expression));
+  public SpinXPathException notAllowedXPathExpression(String expression) {
+    return new SpinXPathException(exceptionMessage("034", "XPath expression '{}' not allowed", expression));
+  }
+
+  public SpinXPathException unableToFindXPathExpression(String expression) {
+    return new SpinXPathException(exceptionMessage("035", "Unable to find XPath expression '{}'", expression));
+  }
+
+  public SpinXmlElementException elementIsNotChildOfThisElement(SpinXmlElement existingChildElement, SpinXmlElement parentDomElement) {
+    return new SpinXmlElementException(exceptionMessage("036", "The element with namespace '{}' and name '{}' " +
+        "is not a child element of the element with namespace '{}' and name '{}'",
+      existingChildElement.namespace(), existingChildElement.name(),
+      parentDomElement.namespace(), parentDomElement.name()
+    ));
   }
 
 }

--- a/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/DomXmlLogger.java
+++ b/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/DomXmlLogger.java
@@ -167,4 +167,9 @@ public class DomXmlLogger extends SpinLogger {
   public SpinXmlDataFormatException unableToSetProperty(String propertyName, String className, Throwable cause) {
     return new SpinXmlDataFormatException(exceptionMessage("033", "Cannot set property '{}' to '{}'", propertyName, className), cause);
   }
+
+  public SpinXmlElementException unableToFindElementWithXPathExpression(String expression) {
+    return new SpinXmlElementException(exceptionMessage("034", "Unable to find element with XPath expression '{}'", expression));
+  }
+
 }

--- a/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/query/DomXPathQuery.java
+++ b/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/query/DomXPathQuery.java
@@ -39,6 +39,8 @@ public class DomXPathQuery extends SpinXPathQuery {
 
   private static final DomXmlLogger LOG = DomXmlLogger.XML_DOM_LOGGER;
 
+  private static final String ROOT_NODE_EXPRESSION = "/";
+
   protected final DomXmlElement domElement;
   protected final XPath query;
   protected final String expression;
@@ -56,8 +58,17 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public SpinXmlElement element() {
+    if (ROOT_NODE_EXPRESSION.equals(expression)) {
+      // throw an exception for '/' expression
+      throw LOG.unableToFindElementWithXPathExpression(expression);
+    }
+
     try {
       Element element = (Element) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODE);
+      if (element == null) {
+        // throw an exception if element doesn't exist
+        throw LOG.unableToFindElementWithXPathExpression(expression);
+      }
       return dataFormat.createElementWrapper(element);
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -69,6 +80,10 @@ public class DomXPathQuery extends SpinXPathQuery {
   public SpinList<SpinXmlElement> elementList() {
     try {
       NodeList nodeList = (NodeList) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODESET);
+      if (nodeList == null || nodeList.getLength() == 0) {
+        // throw an exception if elements don't exist
+        throw LOG.unableToFindElementWithXPathExpression(expression);
+      }
       return new SpinListImpl<SpinXmlElement>(new DomXmlElementIterable(nodeList, dataFormat));
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -78,8 +93,17 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public SpinXmlAttribute attribute() {
+    if (ROOT_NODE_EXPRESSION.equals(expression)) {
+      // throw an exception for '/' expression
+      throw LOG.unableToFindElementWithXPathExpression(expression);
+    }
+
     try {
       Attr attribute = (Attr) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODE);
+      if (attribute == null) {
+        // throw an exception if attribute doesn't exist
+        throw LOG.unableToFindElementWithXPathExpression(expression);
+      }
       return dataFormat.createAttributeWrapper(attribute);
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -91,6 +115,10 @@ public class DomXPathQuery extends SpinXPathQuery {
   public SpinList<SpinXmlAttribute> attributeList() {
     try {
       NodeList nodeList = (NodeList) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODESET);
+      if (nodeList == null || nodeList.getLength() == 0) {
+        // throw an exception if attributes don't exist
+        throw LOG.unableToFindElementWithXPathExpression(expression);
+      }
       return new SpinListImpl<SpinXmlAttribute>(new DomXmlAttributeIterable(nodeList, dataFormat));
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -100,6 +128,11 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public String string() {
+    if (ROOT_NODE_EXPRESSION.equals(expression)) {
+      // throw an exception for '/' expression
+      throw LOG.unableToFindElementWithXPathExpression(expression);
+    }
+
     try {
       return (String) query.evaluate(expression, domElement.unwrap(), XPathConstants.STRING);
     } catch (XPathExpressionException e) {
@@ -110,6 +143,11 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public Double number() {
+    if (ROOT_NODE_EXPRESSION.equals(expression)) {
+      // throw an exception for '/' expression
+      throw LOG.unableToFindElementWithXPathExpression(expression);
+    }
+
     try {
       return (Double) query.evaluate(expression, domElement.unwrap(), XPathConstants.NUMBER);
     } catch (XPathExpressionException e) {
@@ -120,6 +158,11 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public Boolean bool() {
+    if (ROOT_NODE_EXPRESSION.equals(expression)) {
+      // throw an exception for '/' expression
+      throw LOG.unableToFindElementWithXPathExpression(expression);
+    }
+
     try {
       return (Boolean) query.evaluate(expression, domElement.unwrap(), XPathConstants.BOOLEAN);
     } catch (XPathExpressionException e) {

--- a/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/query/DomXPathQuery.java
+++ b/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/query/DomXPathQuery.java
@@ -13,7 +13,12 @@
 
 package org.camunda.spin.impl.xml.dom.query;
 
+import static org.camunda.spin.impl.xml.dom.util.DomXmlEnsure.ensureNotDocumentRootExpression;
+import static org.camunda.spin.impl.xml.dom.util.DomXmlEnsure.ensureXPathNotEmpty;
+import static org.camunda.spin.impl.xml.dom.util.DomXmlEnsure.ensureXPathNotNull;
+
 import java.util.Map;
+
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -38,9 +43,6 @@ import org.w3c.dom.NodeList;
 public class DomXPathQuery extends SpinXPathQuery {
 
   private static final DomXmlLogger LOG = DomXmlLogger.XML_DOM_LOGGER;
-
-  private static final String ROOT_NODE_EXPRESSION = "/";
-
   protected final DomXmlElement domElement;
   protected final XPath query;
   protected final String expression;
@@ -58,17 +60,10 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public SpinXmlElement element() {
-    if (ROOT_NODE_EXPRESSION.equals(expression)) {
-      // throw an exception for '/' expression
-      throw LOG.unableToFindElementWithXPathExpression(expression);
-    }
-
     try {
+      ensureNotDocumentRootExpression(expression);
       Element element = (Element) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODE);
-      if (element == null) {
-        // throw an exception if element doesn't exist
-        throw LOG.unableToFindElementWithXPathExpression(expression);
-      }
+      ensureXPathNotNull(element, expression);
       return dataFormat.createElementWrapper(element);
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -79,11 +74,9 @@ public class DomXPathQuery extends SpinXPathQuery {
 
   public SpinList<SpinXmlElement> elementList() {
     try {
+      ensureNotDocumentRootExpression(expression);
       NodeList nodeList = (NodeList) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODESET);
-      if (nodeList == null || nodeList.getLength() == 0) {
-        // throw an exception if elements don't exist
-        throw LOG.unableToFindElementWithXPathExpression(expression);
-      }
+      ensureXPathNotEmpty(nodeList, expression);
       return new SpinListImpl<SpinXmlElement>(new DomXmlElementIterable(nodeList, dataFormat));
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -93,17 +86,10 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public SpinXmlAttribute attribute() {
-    if (ROOT_NODE_EXPRESSION.equals(expression)) {
-      // throw an exception for '/' expression
-      throw LOG.unableToFindElementWithXPathExpression(expression);
-    }
-
     try {
+      ensureNotDocumentRootExpression(expression);
       Attr attribute = (Attr) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODE);
-      if (attribute == null) {
-        // throw an exception if attribute doesn't exist
-        throw LOG.unableToFindElementWithXPathExpression(expression);
-      }
+      ensureXPathNotNull(attribute, expression);
       return dataFormat.createAttributeWrapper(attribute);
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -114,11 +100,9 @@ public class DomXPathQuery extends SpinXPathQuery {
 
   public SpinList<SpinXmlAttribute> attributeList() {
     try {
+      ensureNotDocumentRootExpression(expression);
       NodeList nodeList = (NodeList) query.evaluate(expression, domElement.unwrap(), XPathConstants.NODESET);
-      if (nodeList == null || nodeList.getLength() == 0) {
-        // throw an exception if attributes don't exist
-        throw LOG.unableToFindElementWithXPathExpression(expression);
-      }
+      ensureXPathNotEmpty(nodeList, expression);
       return new SpinListImpl<SpinXmlAttribute>(new DomXmlAttributeIterable(nodeList, dataFormat));
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -128,12 +112,8 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public String string() {
-    if (ROOT_NODE_EXPRESSION.equals(expression)) {
-      // throw an exception for '/' expression
-      throw LOG.unableToFindElementWithXPathExpression(expression);
-    }
-
     try {
+      ensureNotDocumentRootExpression(expression);
       return (String) query.evaluate(expression, domElement.unwrap(), XPathConstants.STRING);
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -143,12 +123,8 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public Double number() {
-    if (ROOT_NODE_EXPRESSION.equals(expression)) {
-      // throw an exception for '/' expression
-      throw LOG.unableToFindElementWithXPathExpression(expression);
-    }
-
     try {
+      ensureNotDocumentRootExpression(expression);
       return (Double) query.evaluate(expression, domElement.unwrap(), XPathConstants.NUMBER);
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);
@@ -158,12 +134,8 @@ public class DomXPathQuery extends SpinXPathQuery {
   }
 
   public Boolean bool() {
-    if (ROOT_NODE_EXPRESSION.equals(expression)) {
-      // throw an exception for '/' expression
-      throw LOG.unableToFindElementWithXPathExpression(expression);
-    }
-
     try {
+      ensureNotDocumentRootExpression(expression);
       return (Boolean) query.evaluate(expression, domElement.unwrap(), XPathConstants.BOOLEAN);
     } catch (XPathExpressionException e) {
       throw LOG.unableToEvaluateXPathExpressionOnElement(domElement, e);

--- a/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/util/DomXmlEnsure.java
+++ b/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/util/DomXmlEnsure.java
@@ -13,12 +13,12 @@
 package org.camunda.spin.impl.xml.dom.util;
 
 import org.camunda.commons.utils.EnsureUtil;
-import org.camunda.spin.impl.logging.SpinCoreLogger;
-import org.camunda.spin.impl.logging.SpinLogger;
 import org.camunda.spin.impl.xml.dom.DomXmlElement;
+import org.camunda.spin.impl.xml.dom.DomXmlLogger;
+import org.camunda.spin.xml.SpinXPathException;
 import org.camunda.spin.xml.SpinXmlElementException;
 import org.w3c.dom.Node;
-
+import org.w3c.dom.NodeList;
 
 /**
  * A list of generally useful source code assertions provided as static helpers.
@@ -28,7 +28,9 @@ import org.w3c.dom.Node;
  */
 public class DomXmlEnsure extends EnsureUtil {
 
-  private static final SpinCoreLogger LOG = SpinLogger.CORE_LOGGER;
+  private static final DomXmlLogger LOG = DomXmlLogger.XML_DOM_LOGGER;
+
+  private static final String ROOT_EXPRESSION = "/";
 
   /**
    * Ensures that the element is child element of the parent element.
@@ -42,6 +44,44 @@ public class DomXmlEnsure extends EnsureUtil {
     if (parent == null || !parentElement.unwrap().isEqualNode(parent)) {
       throw LOG.elementIsNotChildOfThisElement(childElement, parentElement);
     }
-
   }
+
+  /**
+   * Ensures that the expression is not the root expression '/'.
+   * 
+   * @param expression the expression to ensure to be not the root expression '/'
+   * @throws SpinXPathException if the expression is the root expression '/'
+   */
+  public static void ensureNotDocumentRootExpression(String expression) {
+    if (ROOT_EXPRESSION.equals(expression)) {
+      throw LOG.notAllowedXPathExpression(expression);
+    }
+  }
+
+  /**
+   * Ensure that the node is not null.
+   * 
+   * @param node the node to ensure to be not null
+   * @param expression the expression was used to find the node
+   * @throws SpinXPathException if the node is null
+   */
+  public static void ensureXPathNotNull(Node node, String expression) {
+    if (node == null) {
+      throw LOG.unableToFindXPathExpression(expression);
+    }
+  }
+
+  /**
+   * Ensure that the nodeList is either null or empty.
+   * 
+   * @param nodeList the nodeList to ensure to be either null or empty
+   * @param expression the expression was used to fine the nodeList
+   * @throws SpinXPathException if the nodeList is either null or empty
+   */
+  public static void ensureXPathNotEmpty(NodeList nodeList, String expression) {
+    if (nodeList == null || nodeList.getLength() == 0) {
+      throw LOG.unableToFindXPathExpression(expression);
+    }
+  }
+
 }

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomXPathScriptTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomXPathScriptTest.java
@@ -13,6 +13,8 @@
 
 package org.camunda.spin.xml.dom;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.camunda.spin.SpinList;
 import org.camunda.spin.impl.test.Script;
 import org.camunda.spin.impl.test.ScriptTest;
@@ -21,10 +23,7 @@ import org.camunda.spin.xml.SpinXPathException;
 import org.camunda.spin.xml.SpinXPathQuery;
 import org.camunda.spin.xml.SpinXmlAttribute;
 import org.camunda.spin.xml.SpinXmlElement;
-import org.camunda.spin.xml.SpinXmlElementException;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Sebastian Menski
@@ -35,7 +34,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   private static final String xmlWithNamespace = "<root xmlns:bar=\"http://camunda.org\" xmlns:foo=\"http://camunda.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
   private static final String xmlWithDefaultNamespace = "<root xmlns=\"http://camunda.com/example\" xmlns:bar=\"http://camunda.org\" xmlns:foo=\"http://camunda.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -48,7 +47,20 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     query.element();
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/")
+      }
+    )
+  public void canNotQueryDocumentAsElementList() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.elementList();
+  }
+
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -61,7 +73,20 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     query.attribute();
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/")
+      }
+    )
+  public void canNotQueryDocumentAsAttributeList() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.attributeList();
+  }
+
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -74,7 +99,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     query.string();
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -87,7 +112,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     query.number();
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -115,7 +140,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     assertThat(child.attr("id").value()).isEqualTo("child");
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -155,7 +180,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     assertThat(childs).hasSize(2);
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -182,7 +207,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     assertThat(attribute.value()).isEqualTo("child");
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
@@ -222,7 +247,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     assertThat(attributes).hasSize(2);
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomXPathScriptTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomXPathScriptTest.java
@@ -21,6 +21,7 @@ import org.camunda.spin.xml.SpinXPathException;
 import org.camunda.spin.xml.SpinXPathQuery;
 import org.camunda.spin.xml.SpinXmlAttribute;
 import org.camunda.spin.xml.SpinXmlElement;
+import org.camunda.spin.xml.SpinXmlElementException;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +34,71 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   private static final String xml = "<root><child id=\"child\"><a id=\"a\"/><b id=\"b\"/><a id=\"c\"/></child></root>";
   private static final String xmlWithNamespace = "<root xmlns:bar=\"http://camunda.org\" xmlns:foo=\"http://camunda.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
   private static final String xmlWithDefaultNamespace = "<root xmlns=\"http://camunda.com/example\" xmlns:bar=\"http://camunda.org\" xmlns:foo=\"http://camunda.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/")
+      }
+    )
+  public void canNotQueryDocumentAsElement() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.element();
+  }
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/")
+      }
+    )
+  public void canNotQueryDocumentAsAttribute() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.attribute();
+  }
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/")
+      }
+    )
+  public void canNotQueryDocumentAsString() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.string();
+  }
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/")
+      }
+    )
+  public void canNotQueryDocumentAsNumber() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.number();
+  }
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/")
+      }
+    )
+  public void canNotQueryDocumentAsBoolean() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.bool();
+  }
 
   @Test
   @Script(
@@ -47,6 +113,19 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     SpinXmlElement child = query.element();
     assertThat(child.name()).isEqualTo("child");
     assertThat(child.attr("id").value()).isEqualTo("child");
+  }
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/root/nonExisting")
+      }
+    )
+  public void canNotQueryElement() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.element();
   }
 
   @Test(expected = SpinXPathException.class)
@@ -76,6 +155,46 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     assertThat(childs).hasSize(2);
   }
 
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/root/child/nonExisting")
+      }
+    )
+  public void canNotQueryElementList() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.elementList();
+  }
+
+  @Test
+  @Script(
+    name = "XmlDomXPathScriptTest.xPath",
+    variables = {
+      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "expression", value = "/root/child/@id")
+    }
+  )
+  public void canQueryAttribute() {
+    SpinXPathQuery query = script.getVariable("query");
+    SpinXmlAttribute attribute = query.attribute();
+    assertThat(attribute.value()).isEqualTo("child");
+  }
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/root/child/@nonExisting")
+      }
+    )
+  public void canNotQueryAttribute() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.attribute();
+  }
+
   @Test(expected = SpinXPathException.class)
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
@@ -94,20 +213,6 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
       @ScriptVariable(name = "input", value = xml),
-      @ScriptVariable(name = "expression", value = "/root/child/@id")
-    }
-  )
-  public void canQueryAttribute() {
-    SpinXPathQuery query = script.getVariable("query");
-    SpinXmlAttribute attribute = query.attribute();
-    assertThat(attribute.value()).isEqualTo("child");
-  }
-
-  @Test
-  @Script(
-    name = "XmlDomXPathScriptTest.xPath",
-    variables = {
-      @ScriptVariable(name = "input", value = xml),
       @ScriptVariable(name = "expression", value = "/root/child/a/@id")
     }
   )
@@ -115,6 +220,19 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     SpinXPathQuery query = script.getVariable("query");
     SpinList<SpinXmlAttribute> attributes = query.attributeList();
     assertThat(attributes).hasSize(2);
+  }
+
+  @Test(expected = SpinXmlElementException.class)
+  @Script(
+      name = "XmlDomXPathScriptTest.xPath",
+      variables = {
+        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "expression", value = "/root/child/a/@nonExisting")
+      }
+    )
+  public void canNotQueryAttributeList() {
+    SpinXPathQuery query = script.getVariable("query");
+    query.attributeList();
   }
 
   @Test
@@ -136,6 +254,34 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
       @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "expression", value = "string(/root/child/@nonExisting)")
+    }
+  )
+  public void canQueryNonExistingString() {
+    SpinXPathQuery query = script.getVariable("query");
+    String value = query.string();
+    assertThat(value).isEqualTo("");
+  }
+
+  @Test
+  @Script(
+    name = "XmlDomXPathScriptTest.xPath",
+    variables = {
+      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "expression", value = "string(/)")
+    }
+  )
+  public void canQueryStringAsDocument() {
+    SpinXPathQuery query = script.getVariable("query");
+    String value = query.string();
+    assertThat(value).isEqualTo("");
+  }
+
+  @Test
+  @Script(
+    name = "XmlDomXPathScriptTest.xPath",
+    variables = {
+      @ScriptVariable(name = "input", value = xml),
       @ScriptVariable(name = "expression", value = "count(/root/child/a)")
     }
   )
@@ -143,6 +289,34 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     SpinXPathQuery query = script.getVariable("query");
     Double count = query.number();
     assertThat(count).isEqualTo(2);
+  }
+
+  @Test
+  @Script(
+    name = "XmlDomXPathScriptTest.xPath",
+    variables = {
+      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "expression", value = "count(/root/child/nonExisting)")
+    }
+  )
+  public void canQueryNonExistingNumber() {
+    SpinXPathQuery query = script.getVariable("query");
+    Double count = query.number();
+    assertThat(count).isEqualTo(0);
+  }
+
+  @Test
+  @Script(
+    name = "XmlDomXPathScriptTest.xPath",
+    variables = {
+      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "expression", value = "count(/)")
+    }
+  )
+  public void canQueryNumberAsDocument() {
+    SpinXPathQuery query = script.getVariable("query");
+    Double count = query.number();
+    assertThat(count).isEqualTo(1);
   }
 
   @Test
@@ -164,13 +338,27 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
       @ScriptVariable(name = "input", value = xml),
-      @ScriptVariable(name = "expression", value = "boolean(/root/not)")
+      @ScriptVariable(name = "expression", value = "boolean(/root/nonExisting)")
     }
   )
-  public void canQueryBoolean() {
+  public void canQueryNonExistingBoolean() {
     SpinXPathQuery query = script.getVariable("query");
     Boolean exists = query.bool();
     assertThat(exists).isFalse();
+  }
+
+  @Test
+  @Script(
+    name = "XmlDomXPathScriptTest.xPath",
+    variables = {
+      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "expression", value = "boolean(/)")
+    }
+  )
+  public void canQueryBooleanAsDocument() {
+    SpinXPathQuery query = script.getVariable("query");
+    Boolean exists = query.bool();
+    assertThat(exists).isTrue();
   }
 
   @Test

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomXPathTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomXPathTest.java
@@ -13,19 +13,18 @@
 
 package org.camunda.spin.xml.dom;
 
-import org.camunda.spin.SpinList;
-import org.camunda.spin.xml.SpinXPathException;
-import org.camunda.spin.xml.SpinXmlAttribute;
-import org.camunda.spin.xml.SpinXmlElement;
-import org.camunda.spin.xml.SpinXmlElementException;
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.spin.Spin.S;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.camunda.spin.Spin.S;
+import org.camunda.spin.SpinList;
+import org.camunda.spin.xml.SpinXPathException;
+import org.camunda.spin.xml.SpinXmlAttribute;
+import org.camunda.spin.xml.SpinXmlElement;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Sebastian Menski
@@ -43,27 +42,37 @@ public class XmlDomXPathTest {
     elementWithDefaultNamespace = S("<root xmlns=\"http://camunda.com/example\" xmlns:bar=\"http://camunda.org\" xmlns:foo=\"http://camunda.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>");
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryDocumentAsElement() {
     element.xPath("/").element();
   }
-  
-  @Test(expected = SpinXmlElementException.class)
+
+  @Test(expected = SpinXPathException.class)
+  public void canNotQueryDocumentAsElementList() {
+    element.xPath("/").elementList();
+  }
+
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryDocumentAsAttribute() {
     element.xPath("/").attribute();
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
+  public void canNotQueryDocumentAsAttributeList() {
+    element.xPath("/").attributeList();
+  }
+
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryDocumentAsString() {
     element.xPath("/").string();
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryDocumentAsNumber() {
     element.xPath("/").number();
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryDocumentAsBoolean() {
     element.xPath("/").bool();
   }
@@ -78,8 +87,8 @@ public class XmlDomXPathTest {
     assertThat(b.name()).isEqualTo("b");
     assertThat(b.attr("id").value()).isEqualTo("b");
   }
-  
-  @Test(expected = SpinXmlElementException.class)
+
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryElement() {
     element.xPath("/root/nonExisting").element();
   }
@@ -95,7 +104,7 @@ public class XmlDomXPathTest {
     assertThat(childs).hasSize(2);
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryElementList() {
     element.xPath("/root/child/nonExisting").elementList();
   }
@@ -106,7 +115,7 @@ public class XmlDomXPathTest {
     assertThat(attribute.value()).isEqualTo("child");
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryAttribute() {
     element.xPath("/root/child/@nonExisting").attribute();
   }
@@ -122,7 +131,7 @@ public class XmlDomXPathTest {
     assertThat(attributes).hasSize(2);
   }
 
-  @Test(expected = SpinXmlElementException.class)
+  @Test(expected = SpinXPathException.class)
   public void canNotQueryAttributeList() {
     element.xPath("/root/child/a/@nonExisting").attributeList();
   }


### PR DESCRIPTION
-- throw meaningful exception for root node '/' expression
-- throw exception for non existing elements and attributes

related to CAM-3352