### PR TITLE
JsonPath query fix for Null Nodes

### DIFF
--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/query/JacksonJsonPathQuery.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/query/JacksonJsonPathQuery.java
@@ -43,23 +43,24 @@ public class JacksonJsonPathQuery implements SpinJsonPathQuery {
   }
 
   public SpinJsonNode element() {
-    try {
-      Object result = query.read(spinJsonNode.toString(), dataFormat.getJsonPathConfiguration());
-      if (result != null) {
-        JsonNode node = dataFormat.createJsonNode(result);
-        return dataFormat.createWrapperInstance(node);
-      }
-      else {
-        throw LOG.unableToFindJsonPath(query.getPath(), spinJsonNode.toString());
-      }
-    } catch(PathNotFoundException pex) {
-      throw LOG.unableToEvaluateJsonPathExpressionOnNode(spinJsonNode, pex);
-    } catch (ClassCastException cex) {
-      throw LOG.unableToCastJsonPathResultTo(SpinJsonNode.class, cex);
-    } catch(InvalidPathException iex) {
-      throw LOG.invalidJsonPath(SpinJsonNode.class, iex);
-    }
-  }
+	    try {
+	      Object result = query.read(spinJsonNode.toString(), dataFormat.getJsonPathConfiguration());
+	      JsonNode node = null;
+	      if (result != null) {
+	        node = dataFormat.createJsonNode(result);
+	      }
+	      else {
+	    	  node = dataFormat.createNullJsonNode();
+	      }
+	      return dataFormat.createWrapperInstance(node);
+	    } catch(PathNotFoundException pex) {
+	      throw LOG.unableToEvaluateJsonPathExpressionOnNode(spinJsonNode, pex);
+	    } catch (ClassCastException cex) {
+	      throw LOG.unableToCastJsonPathResultTo(SpinJsonNode.class, cex);
+	    } catch(InvalidPathException iex) {
+	      throw LOG.invalidJsonPath(SpinJsonNode.class, iex);
+	    }
+	  }
 
   public SpinList<SpinJsonNode> elementList() {
     JacksonJsonNode node = (JacksonJsonNode) element();

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeJsonPathTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeJsonPathTest.java
@@ -74,6 +74,12 @@ public class JsonTreeJsonPathTest {
 
     assertThat(order.longValue()).isEqualTo(1234567890987654321L);
   }
+  
+  @Test
+  public void shouldGetNullNode() {
+	  SpinJsonNode node = jsonNode.jsonPath("$.nullValue").element();
+	  assertThat(node.isNull()).isTrue();
+  }
 
   @Test
   public void shouldGetSingleArrayEntry() {


### PR DESCRIPTION
fixed - JacksonJsonPathQuery::element() - Fixed an issue where queries
finding NullNodes were throwing PathNotFoundExceptions.

added - JsonTreeJsonPathTest::shouldGetNullNode() - This test verifies
that JsonPath queries can find and return values for paths that have a
Json NullNode value.

related to CAM-8417