### PR TITLE
Use context class loader for loading JSON mapping target classes.

### DIFF
--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/JacksonJsonDataFormatMapper.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/JacksonJsonDataFormatMapper.java
@@ -60,7 +60,7 @@ public class JacksonJsonDataFormatMapper implements DataFormatMapper {
   public <T> T mapInternalToJava(Object parameter, String typeIdentifier) {
     try {
       //sometimes the class identifier is at once a fully qualified class name
-      final Class<?> aClass = Class.forName(typeIdentifier);
+      final Class<?> aClass = Class.forName(typeIdentifier, true, Thread.currentThread().getContextClassLoader());
       return (T) mapInternalToJava(parameter, aClass);
     } catch (ClassNotFoundException e) {
       JavaType javaType = format.constructJavaTypeFromCanonicalString(typeIdentifier);


### PR DESCRIPTION
The previous implementation is problematic if using Camunda BPM together with Spring Boot's Developer Tools (and possibly other non-trivial classloading environments). If the class to be mapped from JSON already was loaded from another classloader you end up with a ClassCastException like this:

`java.lang.ClassCastException: com.example.MyClassMappedFromJson cannot be cast to com.example.MyClassMappedFromJson`

This is the case if using the Spring Boot Developer Tools. Per default classes in your current project (MyClassMappedFromJson from the example) are loaded with a RestartClassLoader while `Class.forName(typeIdentifer)` loads the class a second time with the current class loader which produces this incompatiblity.

Always using the context class loader fixes the problem: https://docs.spring.io/spring-boot/docs/2.0.4.RELEASE/reference/htmlsingle/#using-boot-devtools-known-restart-limitations