### PR TITLE
chore(project): replace Maven activeByDefault condition to allow combination with other Maven profiles

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -129,7 +129,7 @@
     <profile>
       <id>check-api-compatibility</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <jdk>(,)</jdk>
       </activation>
       <build>
         <plugins>

--- a/dataformat-json-jackson/pom.xml
+++ b/dataformat-json-jackson/pom.xml
@@ -117,7 +117,7 @@
     <profile>
       <id>check-api-compatibility</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <jdk>(,)</jdk>
       </activation>
       <build>
         <plugins>

--- a/dataformat-xml-dom/pom.xml
+++ b/dataformat-xml-dom/pom.xml
@@ -109,7 +109,7 @@
     <profile>
       <id>check-api-compatibility</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <jdk>(,)</jdk>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
The Maven documentation says that it might not work as one would assume:

> All profiles that are active by default are automatically deactivated when a profile in the POM is activated on the command line or through its activation config.

In the end the fixed bug was not caused by the Maven version but by the differing JDK versions that made it hard to reproduce locally because the API backwards compatibility check works with JDK 8 but not with other versions.