### PR TITLE
CAM-9972: feat(spin): allow for DataFormat configuration through static method

### DIFF
--- a/core/src/main/java/org/camunda/spin/DataFormats.java
+++ b/core/src/main/java/org/camunda/spin/DataFormats.java
@@ -16,8 +16,10 @@
  */
 package org.camunda.spin;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -96,7 +98,11 @@ public class DataFormats {
 
   public Set<DataFormat<? extends Spin<?>>> getAllAvailableDataFormats() {
     ensureDataformatsInitialized();
-    return new HashSet<DataFormat<? extends Spin<?>>>(availableDataFormats.values());
+    return new HashSet<>(availableDataFormats.values());
+  }
+
+  protected Map<String, DataFormat<?>> getAvailableDataFormatsMap() {
+    return availableDataFormats;
   }
 
   public DataFormat<? extends Spin<?>> getDataFormatByName(String name) {
@@ -118,6 +124,12 @@ public class DataFormats {
   }
 
   public void registerDataFormats(ClassLoader classloader) {
+    registerDataFormats(classloader, Collections.EMPTY_LIST);
+  }
+
+  public void registerDataFormats(ClassLoader classloader,
+                                  List<DataFormatConfigurator> configurators) {
+
     Map<String, DataFormat<?>> dataFormats = new HashMap<String, DataFormat<?>>();
 
     if(classloader == null) {
@@ -128,7 +140,7 @@ public class DataFormats {
     registerCustomDataFormats(dataFormats, classloader);
 
     // discover and apply data format configurators on the classpath
-    applyConfigurators(dataFormats, classloader);
+    applyConfigurators(dataFormats, classloader, configurators);
 
     LOG.logDataFormats(dataFormats.values());
 
@@ -160,9 +172,23 @@ public class DataFormats {
 
   @SuppressWarnings("rawtypes")
   protected void applyConfigurators(Map<String, DataFormat<?>> dataFormats, ClassLoader classloader) {
+    applyConfigurators(dataFormats, classloader, Collections.EMPTY_LIST);
+  }
+
+  protected void applyConfigurators(Map<String, DataFormat<?>> dataFormats,
+                                    ClassLoader classloader,
+                                    List<DataFormatConfigurator> dataFormatConfigurators) {
+
     ServiceLoader<DataFormatConfigurator> configuratorLoader = ServiceLoader.load(DataFormatConfigurator.class, classloader);
 
+    // apply SPI configurators
     for (DataFormatConfigurator configurator : configuratorLoader) {
+      LOG.logDataFormatConfigurator(configurator);
+      applyConfigurator(dataFormats, configurator);
+    }
+
+    // apply additional, non-SPI, configurators
+    for (DataFormatConfigurator configurator : dataFormatConfigurators) {
       LOG.logDataFormatConfigurator(configurator);
       applyConfigurator(dataFormats, configurator);
     }
@@ -183,6 +209,10 @@ public class DataFormats {
 
   public static void loadDataFormats(ClassLoader classloader) {
     INSTANCE.registerDataFormats(classloader);
+  }
+
+  public static void loadDataFormats(ClassLoader classloader, List<DataFormatConfigurator> configurators) {
+    INSTANCE.registerDataFormats(classloader, configurators);
   }
 
 }

--- a/core/src/main/java/org/camunda/spin/DataFormats.java
+++ b/core/src/main/java/org/camunda/spin/DataFormats.java
@@ -101,10 +101,6 @@ public class DataFormats {
     return new HashSet<>(availableDataFormats.values());
   }
 
-  protected Map<String, DataFormat<?>> getAvailableDataFormatsMap() {
-    return availableDataFormats;
-  }
-
   public DataFormat<? extends Spin<?>> getDataFormatByName(String name) {
     ensureDataformatsInitialized();
     return availableDataFormats.get(name);

--- a/core/src/test/java/org/camunda/spin/spi/DataFormatLoadingTest.java
+++ b/core/src/test/java/org/camunda/spin/spi/DataFormatLoadingTest.java
@@ -22,6 +22,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
@@ -44,7 +45,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  * @author Thorben Lindhauer
  */
 @RunWith(PowerMockRunner.class)
-public class DataFormatProviderTest {
+public class DataFormatLoadingTest {
 
   protected ServiceLoader<DataFormatProvider> mockServiceLoader;
 
@@ -94,6 +95,44 @@ public class DataFormatProviderTest {
     // then the configuration was applied
     ExampleCustomDataFormat customFormat = (ExampleCustomDataFormat) format;
     assertThat(customFormat.getProperty()).isEqualTo(ExampleCustomDataFormatConfigurator.UPDATED_PROPERTY);
+  }
+
+  @Test
+  @PrepareForTest(DataFormats.class)
+  public void testConfigureDataFormatWithConfiguratorList() {
+    // given a custom data format provider that is returned by the service loader API
+    mockProviders(new CustomDataFormatProvider());
+    mockConfigurators();
+    DataFormatConfigurator configurator = new ExampleCustomDataFormatConfigurator();
+
+    // when a list of data format configurators is passed to the "load" method
+    DataFormats.loadDataFormats(DataFormats.class.getClassLoader(),
+                                Collections.singletonList(configurator));
+
+    // then the configuration was applied
+    ExampleCustomDataFormat customFormat = (ExampleCustomDataFormat) DataFormats
+        .getDataFormat(CustomDataFormatProvider.NAME);
+    assertThat(customFormat.getProperty())
+        .isEqualTo(ExampleCustomDataFormatConfigurator.UPDATED_PROPERTY);
+  }
+
+  @Test
+  @PrepareForTest(DataFormats.class)
+  public void testRegisterDataFormatWithConfiguratorList() {
+    // given a custom data format provider that is returned by the service loader API
+    mockProviders(new CustomDataFormatProvider());
+    mockConfigurators();
+    DataFormatConfigurator configurator = new ExampleCustomDataFormatConfigurator();
+
+    // when a list of data format configurators is passed to the "load" method
+    DataFormats.getInstance().registerDataFormats(DataFormats.class.getClassLoader(),
+                                                  Collections.singletonList(configurator));
+
+    // then the configuration was applied
+    ExampleCustomDataFormat customFormat = (ExampleCustomDataFormat) DataFormats
+        .getDataFormat(CustomDataFormatProvider.NAME);
+    assertThat(customFormat.getProperty())
+        .isEqualTo(ExampleCustomDataFormatConfigurator.UPDATED_PROPERTY);
   }
 
   protected void mockProviders(final DataFormatProvider... providers) {


### PR DESCRIPTION

* Allow to apply DataFormatConfigurators directly on the DataFormats Singleton instance when loading DataFormats.

Related to [CAM-9972](https://app.camunda.com/jira/browse/CAM-9972)