### PR TITLE
[CAM-10714] chore(spin): use whitelist for JSON deserialization

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,10 +10,6 @@
   <artifactId>camunda-spin-core</artifactId>
   <name>camunda Spin - core</name>
 
-  <properties>
-    <powermock.version>1.5.6</powermock.version>
-  </properties>
-
   <dependencies>
 
     <dependency>
@@ -71,13 +67,11 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/core/src/main/java/org/camunda/spin/DeserializationTypeValidator.java
+++ b/core/src/main/java/org/camunda/spin/DeserializationTypeValidator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin;
+
+public interface DeserializationTypeValidator {
+
+  boolean validate(String type);
+
+}

--- a/core/src/main/java/org/camunda/spin/spi/DataFormatMapper.java
+++ b/core/src/main/java/org/camunda/spin/spi/DataFormatMapper.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.spin.spi;
 
+import org.camunda.spin.DeserializationTypeValidator;
+
 /**
  * Maps a java object to the data format's internal representation and vice versa.
  *
@@ -41,7 +43,7 @@ public interface DataFormatMapper {
 
   /**
    * Maps the internal representation of a data format to a java object of the
-   * desired class.
+   * desired class. The desired class is not validated prior to the mapping.
    *
    * @param parameter the object to be mapped
    * @param type the class to map the object to
@@ -52,9 +54,24 @@ public interface DataFormatMapper {
 
   /**
    * Maps the internal representation of a data format to a java object of the
+   * desired class. The desired class is validated by the <code>validator</code>
+   * prior to the mapping.
+   *
+   * @param parameter the object to be mapped
+   * @param type the class to map the object to
+   * @param validator the validator for the target class
+   * @return a java object of the specified class that was populated with the input
+   * parameter
+   */
+
+  public <T> T mapInternalToJava(Object parameter, Class<T> type, DeserializationTypeValidator validator);
+
+  /**
+   * Maps the internal representation of a data format to a java object of the
    * desired class. The type identifier is given in a data format specific format. Its
    * interpretation is data-format-specific. For example, it can be used to express generic
    * type information that cannot be expressed by a {@link Class} object.
+   * The desired class is not validated prior to the mapping.
    *
    * @param parameter the object to be mapped
    * @param typeIdentifier a data-format-specific type identifier that describes
@@ -63,6 +80,22 @@ public interface DataFormatMapper {
    *   parameter
    */
   public <T> T mapInternalToJava(Object parameter, String typeIdentifier);
+
+  /**
+   * Maps the internal representation of a data format to a java object of the
+   * desired class. The type identifier is given in a data format specific format. Its
+   * interpretation is data-format-specific. For example, it can be used to express generic
+   * type information that cannot be expressed by a {@link Class} object.
+   * The desired class is validated by the <code>validator</code> prior to the mapping.
+   *
+   * @param parameter the object to be mapped
+   * @param typeIdentifier a data-format-specific type identifier that describes
+   *   the class to map to
+   * @param validator the validator for the target class
+   * @return a java object of the specified type that was populated with the input
+   *   parameter
+   */
+  public <T> T mapInternalToJava(Object parameter, String typeIdentifier, DeserializationTypeValidator validator);
 
   String getCanonicalTypeName(Object object);
 }

--- a/dataformat-json-jackson/pom.xml
+++ b/dataformat-json-jackson/pom.xml
@@ -89,6 +89,18 @@
       <artifactId>json-unit-fluent</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/JacksonJsonNode.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/JacksonJsonNode.java
@@ -463,7 +463,8 @@ public class JacksonJsonNode extends SpinJsonNode {
   }
 
   /**
-   * Maps the json represented by this object to a java object of the given type.
+   * Maps the json represented by this object to a java object of the given type.<br>
+   * Note: the desired target type is not validated and needs to be trusted.
    *
    * @throws SpinJsonException if the json representation cannot be mapped to the specified type
    */
@@ -475,7 +476,8 @@ public class JacksonJsonNode extends SpinJsonNode {
   /**
    * Maps the json represented by this object to a java object of the given type.
    * Argument is to be supplied in Jackson's canonical type string format
-   * (see {@link JavaType#toCanonical()}).
+   * (see {@link JavaType#toCanonical()}).<br>
+   * Note: the desired target type is not validated and needs to be trusted.
    *
    * @throws SpinJsonException if the json representation cannot be mapped to the specified type
    * @throws SpinJsonDataFormatException if the parameter does not match a valid type
@@ -486,7 +488,8 @@ public class JacksonJsonNode extends SpinJsonNode {
   }
 
   /**
-   * Maps the json represented by this object to a java object of the given type.
+   * Maps the json represented by this object to a java object of the given type.<br>
+   * Note: the desired target type is not validated and needs to be trusted.
    *
    * @throws SpinJsonException if the json representation cannot be mapped to the specified type
    */

--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/CollectionJacksonJsonTypeDetector.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/CollectionJacksonJsonTypeDetector.java
@@ -17,15 +17,14 @@
 package org.camunda.spin.impl.json.jackson.format;
 
 import java.lang.reflect.TypeVariable;
-import java.util.List;
-
+import java.util.Collection;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-public class ListJacksonJsonTypeDetector extends AbstractJacksonJsonTypeDetector {
+public class CollectionJacksonJsonTypeDetector extends AbstractJacksonJsonTypeDetector {
 
   public boolean canHandle(Object object) {
-    return object instanceof List;
+    return object instanceof Collection;
   }
 
   public String detectType(Object object) {
@@ -35,12 +34,12 @@ public class ListJacksonJsonTypeDetector extends AbstractJacksonJsonTypeDetector
   protected JavaType constructType(Object object) {
     TypeFactory typeFactory = TypeFactory.defaultInstance();
 
-    if (object instanceof List && !((List<?>) object).isEmpty()) {
-      List<?> list = (List<?>) object;
-      Object firstElement = list.get(0);
-      if (bindingsArePresent(list.getClass())) {
+    if (object instanceof Collection && !((Collection<?>) object).isEmpty()) {
+      Collection<?> collection = (Collection<?>) object;
+      Object firstElement = collection.iterator().next();
+      if (bindingsArePresent(collection.getClass())) {
         final JavaType elementType = constructType(firstElement);
-        return typeFactory.constructCollectionType(list.getClass(), elementType);
+        return typeFactory.constructCollectionType(collection.getClass(), elementType);
       }
     }
     return typeFactory.constructType(object.getClass());

--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/JacksonJsonDataFormat.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/JacksonJsonDataFormat.java
@@ -115,8 +115,9 @@ public class JacksonJsonDataFormat implements DataFormat<SpinJsonNode> {
 
 
   protected void initTypeDetectors() {
-    typeDetectors = new ArrayList<TypeDetector>();
-    typeDetectors.add(new ListJacksonJsonTypeDetector());
+    typeDetectors = new ArrayList<>();
+    typeDetectors.add(new CollectionJacksonJsonTypeDetector());
+    typeDetectors.add(new MapJacksonJsonTypeDetector());
     typeDetectors.add(new DefaultJsonJacksonTypeDetector());
   }
 

--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/MapJacksonJsonTypeDetector.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/MapJacksonJsonTypeDetector.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.impl.json.jackson.format;
+
+import java.lang.reflect.TypeVariable;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+public class MapJacksonJsonTypeDetector extends AbstractJacksonJsonTypeDetector {
+
+  public boolean canHandle(Object object) {
+    return object instanceof Map;
+  }
+
+  public String detectType(Object object) {
+    return constructType(object).toCanonical();
+  }
+
+  protected JavaType constructType(Object object) {
+    TypeFactory typeFactory = TypeFactory.defaultInstance();
+
+    if (object instanceof Map && !((Map<?, ?>) object).isEmpty()) {
+      Map<?, ?> map = (Map<?, ?>) object;
+      Object keyElement = map.keySet().iterator().next();
+      Object valueElement = map.get(keyElement);
+      if (bindingsArePresent(map.getClass())) {
+        final JavaType keyType = constructType(keyElement);
+        final JavaType valueType = constructType(valueElement);
+        return typeFactory.constructMapType(map.getClass(), keyType, valueType);
+      }
+    }
+    return typeFactory.constructType(object.getClass());
+  }
+
+  private boolean bindingsArePresent(Class<?> erasedType) {
+    TypeVariable<?>[] vars = erasedType.getTypeParameters();
+    int varLen = (vars == null) ? 0 : vars.length;
+    if (varLen == 0) {
+      return false;
+    }
+    if (varLen != 2) {
+      throw new IllegalArgumentException("Cannot create TypeBindings for class " + erasedType.getName() + " with 2 type parameter: class expects " + varLen);
+    }
+    return true;
+  }
+
+}

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/impl/json/jackson/format/JsonDeserializationValidationTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/impl/json/jackson/format/JsonDeserializationValidationTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.impl.json.jackson.format;
+
+import static org.mockito.Mockito.times;
+
+import org.camunda.spin.DeserializationTypeValidator;
+import org.camunda.spin.SpinRuntimeException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+public class JsonDeserializationValidationTest {
+
+  protected DeserializationTypeValidator validator;
+  protected static JacksonJsonDataFormat format;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @BeforeClass
+  public static void setUpMocks() {
+    format = new JacksonJsonDataFormat("test");
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    format = null;
+  }
+
+  @Test
+  public void shouldValidateNothingForPrimitiveClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(int.class);
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(type, validator);
+
+    // then
+    Mockito.verifyZeroInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateBaseTypeOnlyForBaseClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(String.class);
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(type, validator);
+
+    // then
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateBaseTypeOnlyForComplexClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Complex.class);
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(type, validator);
+
+    // then
+    Mockito.verify(validator).validate("org.camunda.spin.impl.json.jackson.format.JsonDeserializationValidationTest$Complex");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateContentTypeOnlyForArrayClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Integer[].class);
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(type, validator);
+
+    // then
+    Mockito.verify(validator).validate("java.lang.Integer");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateCollectionAndContentTypeForCollectionClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.ArrayList<java.lang.String>");
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(type, validator);
+
+    // then
+    Mockito.verify(validator).validate("java.util.ArrayList");
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateCollectionAndContentTypeForNestedCollectionClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.ArrayList<java.util.ArrayList<java.lang.String>>");
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(type, validator);
+
+    // then
+    Mockito.verify(validator, times(2)).validate("java.util.ArrayList");
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateMapAndKeyAndContentTypeForMapClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.HashMap<java.lang.String, java.lang.Integer>");
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(type, validator);
+
+    // then
+    Mockito.verify(validator).validate("java.util.HashMap");
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verify(validator).validate("java.lang.Integer");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldFailForSimpleClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(String.class);
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("[java.lang.String]");
+
+    // when
+    format.getMapper().validateType(type, validator);
+  }
+
+  @Test
+  public void shouldFailForComplexClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Complex.class);
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("[org.camunda.spin.impl.json.jackson.format.JsonDeserializationValidationTest$Complex]");
+
+    // when
+    format.getMapper().validateType(type, validator);
+  }
+
+  @Test
+  public void shouldFailForArrayClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Integer[].class);
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("[java.lang.Integer]");
+
+    // when
+    format.getMapper().validateType(type, validator);
+  }
+
+  @Test
+  public void shouldFailForCollectionClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.ArrayList<java.lang.String>");
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("[java.util.ArrayList, java.lang.String]");
+
+    // when
+    format.getMapper().validateType(type, validator);
+  }
+
+  @Test
+  public void shouldFailForMapClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.HashMap<java.lang.String, java.lang.Integer>");
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("[java.util.HashMap, java.lang.String, java.lang.Integer]");
+
+    // when
+    format.getMapper().validateType(type, validator);
+  }
+
+  @Test
+  public void shouldFailOnceForMapClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.HashMap<java.lang.String, java.lang.String>");
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("[java.util.HashMap, java.lang.String]");
+
+    // when
+    format.getMapper().validateType(type, validator);
+  }
+
+  public static class Complex {
+    private Nested nested;
+
+    public Nested getNested() {
+      return nested;
+    }
+  }
+
+  public static class Nested {
+    private int testInt;
+
+    public int getTestInt() {
+      return testInt;
+    }
+  }
+
+  protected DeserializationTypeValidator createValidatorMock(boolean result) {
+    DeserializationTypeValidator newValidator = Mockito.mock(DeserializationTypeValidator.class);
+    Mockito.when(newValidator.validate(Mockito.anyString())).thenReturn(result);
+    return newValidator;
+  }
+}

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/JsonSerializationTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/JsonSerializationTest.java
@@ -45,7 +45,7 @@ public class JsonSerializationTest {
 
   @Test
   public void testNotGenericList() throws Exception {
-    CustomerList customers = new CustomerList();
+    CustomerList<RegularCustomer> customers = new CustomerList<>();
     customers.add(new RegularCustomer("someCustomer", 5));
 
     String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
@@ -57,7 +57,7 @@ public class JsonSerializationTest {
     final Object o = deserializeFromByteArray(bytes, canonicalTypeString);
     assertThat(o).isInstanceOf(CustomerList.class);
 
-    CustomerList deserializedCustomerList = (CustomerList) o;
+    CustomerList<?> deserializedCustomerList = (CustomerList<?>) o;
     assertEquals("someCustomer", deserializedCustomerList.get(0).getName());
     assertEquals(5, deserializedCustomerList.get(0).getContractStartDate());
   }
@@ -99,7 +99,7 @@ public class JsonSerializationTest {
 
   @Test
   public void testGenericList() throws Exception {
-    GenericCustomerList customers = new GenericCustomerList();
+    GenericCustomerList<RegularCustomer> customers = new GenericCustomerList<>();
     customers.add(new RegularCustomer("someCustomer", 5));
 
     String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
@@ -111,7 +111,7 @@ public class JsonSerializationTest {
     final Object o = deserializeFromByteArray(bytes, canonicalTypeString);
     assertThat(o).isInstanceOf(GenericCustomerList.class);
 
-    GenericCustomerList deserializedCustomerList = (GenericCustomerList) o;
+    GenericCustomerList<?> deserializedCustomerList = (GenericCustomerList<?>) o;
     assertEquals("someCustomer", deserializedCustomerList.get(0).getName());
     assertEquals(5, deserializedCustomerList.get(0).getContractStartDate());
 
@@ -119,7 +119,7 @@ public class JsonSerializationTest {
 
   @Test
   public void serializeAndDeserializeGenericCollection() throws Exception {
-    List<DmnDecisionResultEntries> ruleResults = new ArrayList<DmnDecisionResultEntries>();
+    List<DmnDecisionResultEntries> ruleResults = new ArrayList<>();
     final DmnDecisionResultEntriesImpl result1 = new DmnDecisionResultEntriesImpl();
     result1.putValue("key1", "value1");
     result1.putValue("key2", "value2");
@@ -145,10 +145,10 @@ public class JsonSerializationTest {
     final byte[] bytes = new String("{\"foo\": \"bar\"}").getBytes();
     assertThat(bytes).isNotEmpty();
 
-    final Object o = deserializeFromByteArray(bytes, "java.util.HashMap");
+    final Object o = deserializeFromByteArray(bytes, "java.util.HashMap<java.lang.String, java.lang.String>");
     assertThat(o).isInstanceOf(HashMap.class);
-    assertTrue(((HashMap)o).containsKey("foo"));
-    assertEquals("bar", ((HashMap)o).get("foo"));
+    assertTrue(((HashMap<?, ?>)o).containsKey("foo"));
+    assertEquals("bar", ((HashMap<?, ?>)o).get("foo"));
   }
 
   protected byte[] serializeToByteArray(Object deserializedObject) throws Exception {
@@ -181,12 +181,16 @@ public class JsonSerializationTest {
 
     try {
       Object mappedObject = reader.readInput(bufferedReader);
-      return mapper.mapInternalToJava(mappedObject, objectTypeName);
+      return doDeserialization(mapper, mappedObject, objectTypeName);
     } finally {
       bais.close();
       inReader.close();
       bufferedReader.close();
     }
+  }
+
+  protected Object doDeserialization(DataFormatMapper mapper, Object mappedObject, String objectTypeName) {
+    return mapper.mapInternalToJava(mappedObject, objectTypeName);
   }
 
 }

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/JsonSerializationWithValidationTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/JsonSerializationWithValidationTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.json;
+
+import org.camunda.spin.DeserializationTypeValidator;
+import org.camunda.spin.spi.DataFormatMapper;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+public class JsonSerializationWithValidationTest extends JsonSerializationTest {
+
+  protected DeserializationTypeValidator validator;
+
+  @Before
+  public void setUpValidator() {
+    validator = Mockito.mock(DeserializationTypeValidator.class);
+    Mockito.when(validator.validate(Mockito.anyString())).thenReturn(true);
+  }
+
+  @Override
+  protected Object doDeserialization(DataFormatMapper mapper, Object mappedObject, String objectTypeName) {
+    return mapper.mapInternalToJava(mappedObject, objectTypeName, validator);
+  }
+
+}

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/type/JsonJacksonTreeTypeDetectionTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/type/JsonJacksonTreeTypeDetectionTest.java
@@ -21,7 +21,11 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.camunda.spin.DataFormats.json;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.camunda.spin.json.mapping.Customer;
 import org.camunda.spin.json.mapping.RegularCustomer;
@@ -38,7 +42,7 @@ public class JsonJacksonTreeTypeDetectionTest {
 
   @Test
   public void shouldDetectListType() {
-    List<Customer> customers = new ArrayList<Customer>();
+    List<Customer> customers = new ArrayList<>();
     customers.add(new RegularCustomer());
 
     String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
@@ -47,10 +51,44 @@ public class JsonJacksonTreeTypeDetectionTest {
 
   @Test
   public void shouldDetectListTypeFromEmptyList() {
-    List<RegularCustomer> customers = new ArrayList<RegularCustomer>();
+    List<RegularCustomer> customers = new ArrayList<>();
 
     String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
     assertThat(canonicalTypeString).isEqualTo("java.util.ArrayList<java.lang.Object>");
+  }
+
+  @Test
+  public void shouldDetectSetType() {
+    Set<Customer> customers = new HashSet<>();
+    customers.add(new RegularCustomer());
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.HashSet<org.camunda.spin.json.mapping.RegularCustomer>");
+  }
+
+  @Test
+  public void shouldDetectSetTypeFromEmptySet() {
+    Set<RegularCustomer> customers = new HashSet<>();
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.HashSet<java.lang.Object>");
+  }
+
+  @Test
+  public void shouldDetectMapType() {
+    Map<String, Customer> customers = new HashMap<>();
+    customers.put("foo", new RegularCustomer());
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.HashMap<java.lang.String,org.camunda.spin.json.mapping.RegularCustomer>");
+  }
+
+  @Test
+  public void shouldDetectMapTypeFromEmptyMap() {
+    Map<Integer, RegularCustomer> customers = new HashMap<>();
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(customers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.HashMap<java.lang.Object,java.lang.Object>");
   }
 
   @Test
@@ -65,13 +103,57 @@ public class JsonJacksonTreeTypeDetectionTest {
 
   @Test
   public void shouldHandleListOfLists() {
-    List<List<RegularCustomer>> nestedCustomers = new ArrayList<List<RegularCustomer>>();
-    List<RegularCustomer> customers = new ArrayList<RegularCustomer>();
+    List<List<RegularCustomer>> nestedCustomers = new ArrayList<>();
+    List<RegularCustomer> customers = new ArrayList<>();
     customers.add(new RegularCustomer());
     nestedCustomers.add(customers);
 
     String canonicalTypeString = json().getMapper().getCanonicalTypeName(nestedCustomers);
     assertThat(canonicalTypeString).isEqualTo("java.util.ArrayList<java.util.ArrayList<org.camunda.spin.json.mapping.RegularCustomer>>");
+  }
+
+  @Test
+  public void shouldHandleListOfSets() {
+    List<Set<RegularCustomer>> nestedCustomers = new ArrayList<>();
+    Set<RegularCustomer> customers = new HashSet<>();
+    customers.add(new RegularCustomer());
+    nestedCustomers.add(customers);
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(nestedCustomers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.ArrayList<java.util.HashSet<org.camunda.spin.json.mapping.RegularCustomer>>");
+  }
+
+  @Test
+  public void shouldHandleSetOfSets() {
+    Set<Set<RegularCustomer>> nestedCustomers = new HashSet<>();
+    Set<RegularCustomer> customers = new HashSet<>();
+    customers.add(new RegularCustomer());
+    nestedCustomers.add(customers);
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(nestedCustomers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.HashSet<java.util.HashSet<org.camunda.spin.json.mapping.RegularCustomer>>");
+  }
+
+  @Test
+  public void shouldHandleSetOfLists() {
+    Set<List<RegularCustomer>> nestedCustomers = new HashSet<>();
+    List<RegularCustomer> customers = new ArrayList<>();
+    customers.add(new RegularCustomer());
+    nestedCustomers.add(customers);
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(nestedCustomers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.HashSet<java.util.ArrayList<org.camunda.spin.json.mapping.RegularCustomer>>");
+  }
+
+  @Test
+  public void shouldHandleMapOfMaps() {
+    Map<String, Map<Integer, RegularCustomer>> nestedCustomers = new HashMap<>();
+    Map<Integer, RegularCustomer> customers = new HashMap<>();
+    customers.put(42, new RegularCustomer());
+    nestedCustomers.put("foo", customers);
+
+    String canonicalTypeString = json().getMapper().getCanonicalTypeName(nestedCustomers);
+    assertThat(canonicalTypeString).isEqualTo("java.util.HashMap<java.lang.String,java.util.HashMap<java.lang.Integer,org.camunda.spin.json.mapping.RegularCustomer>>");
   }
 
 }

--- a/dataformat-xml-dom/pom.xml
+++ b/dataformat-xml-dom/pom.xml
@@ -61,6 +61,18 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/impl/xml/dom/format/DomXmlDeserializationValidationTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/impl/xml/dom/format/DomXmlDeserializationValidationTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.impl.xml.dom.format;
+
+import org.camunda.spin.DeserializationTypeValidator;
+import org.camunda.spin.SpinRuntimeException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+public class DomXmlDeserializationValidationTest {
+
+  protected DeserializationTypeValidator validator;
+  protected static DomXmlDataFormat format;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @BeforeClass
+  public static void setUpMocks() {
+    format = new DomXmlDataFormat("test");
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    format = null;
+  }
+
+  @Test
+  public void shouldValidateNothingForPrimitiveClass() {
+    // given
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(int.class, validator);
+
+    // then
+    Mockito.verifyZeroInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateBaseTypeOnlyForBaseClass() {
+    // given
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(String.class, validator);
+
+    // then
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateBaseTypeOnlyForComplexClass() {
+    // given
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(Complex.class, validator);
+
+    // then
+    Mockito.verify(validator).validate("org.camunda.spin.impl.xml.dom.format.DomXmlDeserializationValidationTest$Complex");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateContentTypeOnlyForArrayClass() {
+    // given
+    validator = createValidatorMock(true);
+
+    // when
+    format.getMapper().validateType(Integer[].class, validator);
+
+    // then
+    Mockito.verify(validator).validate("java.lang.Integer");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldFailForSimpleClass() {
+    // given
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("'java.lang.String'");
+
+    // when
+    format.getMapper().validateType(String.class, validator);
+  }
+
+  @Test
+  public void shouldFailForComplexClass() {
+    // given
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("'org.camunda.spin.impl.xml.dom.format.DomXmlDeserializationValidationTest$Complex'");
+
+    // when
+    format.getMapper().validateType(Complex.class, validator);
+  }
+
+  @Test
+  public void shouldFailForArrayClass() {
+    // given
+    validator = createValidatorMock(false);
+
+    // then
+    thrown.expect(SpinRuntimeException.class);
+    thrown.expectMessage("'java.lang.Integer'");
+
+    // when
+    format.getMapper().validateType(Integer[].class, validator);
+  }
+
+  public static class Complex {
+    private Nested nested;
+
+    public Nested getNested() {
+      return nested;
+    }
+  }
+
+  public static class Nested {
+    private int testInt;
+
+    public int getTestInt() {
+      return testInt;
+    }
+  }
+
+  protected DeserializationTypeValidator createValidatorMock(boolean result) {
+    DeserializationTypeValidator newValidator = Mockito.mock(DeserializationTypeValidator.class);
+    Mockito.when(newValidator.validate(Mockito.anyString())).thenReturn(result);
+    return newValidator;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <spin.version.old>1.6.11</spin.version.old>
     <groovy.version>2.4.13</groovy.version>
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
+    <powermock.version>1.5.6</powermock.version>
   </properties>
 
   <dependencyManagement>
@@ -52,6 +53,18 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>2.9.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${powermock.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
[![CAM-10714](https://badgen.net/badge/JIRA/CAM-10714/0052CC)](https://app.camunda.com/jira/browse/CAM-10714)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* create validator interface
* add validator parameter in general deserialization methods
* use validator in JSON & XML deserialization methods
* enhance JSON List type detector to detect Collections in general
* add JSON Map type detector
* if Spin is initialized via Spin Plugin, the validator is hold
  in the plugin instance and passed on to Spin in method calls

related to CAM-10714