### PR TITLE
CAM-10419: generate dependency BOM for dataformat-all

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>

--- a/dataformat-all/pom.xml
+++ b/dataformat-all/pom.xml
@@ -10,6 +10,12 @@
   <artifactId>camunda-spin-dataformat-all</artifactId>
   <name>camunda Spin - all dataformats in one</name>
 
+  <properties>
+    <!-- We shade artifacts into the jar, so we need to generate 
+    a dependency BOM for the license book -->
+    <skip-third-party-bom>false</skip-third-party-bom>
+  </properties>
+  
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
- needed for license book as we shade JARs into this artifact

related to CAM-10419