### PR TITLE
CAM-12182: bump release parent 2.2.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>

--- a/dataformat-all/pom.xml
+++ b/dataformat-all/pom.xml
@@ -40,7 +40,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
- consumes updated maven-shade-plugin configuration so that third-party
  NOTICE files are concatenated

related to CAM-12182