### PR TITLE
fix(json-jackson): use Double as Number default

### DIFF
--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/JacksonJsonDataFormat.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/format/JacksonJsonDataFormat.java
@@ -235,7 +235,7 @@ public class JacksonJsonDataFormat implements DataFormat<SpinJsonNode> {
       return createJsonNode((Long) parameter);
 
     } else if(parameter instanceof Number) {
-      return createJsonNode(((Number) parameter).floatValue());
+      return createJsonNode(((Number) parameter).doubleValue());
 
     } else if(parameter instanceof List) {
       return createJsonNode((List<Object>) parameter);
@@ -259,6 +259,10 @@ public class JacksonJsonDataFormat implements DataFormat<SpinJsonNode> {
   }
 
   public JsonNode createJsonNode(Float parameter) {
+    return objectMapper.getNodeFactory().numberNode(parameter);
+  }
+
+  public JsonNode createJsonNode(Double parameter) {
     return objectMapper.getNodeFactory().numberNode(parameter);
   }
 

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/JsonTestConstants.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/JsonTestConstants.java
@@ -61,8 +61,8 @@ public class JsonTestConstants {
 
     OrderDetails orderDetails = new OrderDetails();
     orderDetails.setArticle("camundaBPM");
-    orderDetails.setPrice(32000.45);
-    orderDetails.setRoundedPrice(32000);
+    orderDetails.setPrice(1234567.455d);
+    orderDetails.setRoundedPrice(1234567L);
 
     List<String> currencies = new ArrayList<String>();
     currencies.add("euro");
@@ -92,8 +92,8 @@ public class JsonTestConstants {
     OrderDetails orderDetails = order.getOrderDetails();
     assertThat(orderDetails).isNotNull();
     assertThat(orderDetails.getArticle()).isEqualTo("camundaBPM");
-    assertThat(orderDetails.getPrice()).isBetween(32000.44449, 32000.45001);
-    assertThat(orderDetails.getRoundedPrice()).isEqualTo(32000);
+    assertThat(orderDetails.getPrice()).isEqualTo(1234567.455d);
+    assertThat(orderDetails.getRoundedPrice()).isEqualTo(1234567L);
     assertThat(orderDetails.getCurrencies()).containsExactly("euro", "dollar");
 
     List<RegularCustomer> customers = order.getCustomers();

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/mapping/OrderDetails.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/mapping/OrderDetails.java
@@ -22,7 +22,7 @@ public class OrderDetails {
 
   private String article;
   private double price;
-  private int roundedPrice;
+  private long roundedPrice;
   private List<String> currencies;
   private boolean paid;
 
@@ -38,10 +38,10 @@ public class OrderDetails {
   public void setPrice(double price) {
     this.price = price;
   }
-  public int getRoundedPrice() {
+  public long getRoundedPrice() {
     return roundedPrice;
   }
-  public void setRoundedPrice(int roundedPrice) {
+  public void setRoundedPrice(long roundedPrice) {
     this.roundedPrice = roundedPrice;
   }
   public List<String> getCurrencies() {

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeJsonPathScriptTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeJsonPathScriptTest.java
@@ -79,7 +79,7 @@ public abstract class JsonTreeJsonPathScriptTest extends ScriptTest {
   public void shouldGetNumberFromJsonPath() {
     Number number = script.getVariable("numberValue");
 
-    assertThat(number.longValue()).isEqualTo(1234567890987654321L);
+    assertThat(number.doubleValue()).isEqualTo(1234567.455d);
   }
 
   @Test

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeReadPropertyScriptTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeReadPropertyScriptTest.java
@@ -202,7 +202,7 @@ public abstract class JsonTreeReadPropertyScriptTest extends ScriptTest {
 
     // python returns bigInt instead of Long
     assertThat(value2.longValue()).isEqualTo(1234567890987654321L);
-    assertThat(value3).isEqualTo(32000.45);
+    assertThat(value3).isEqualTo(1234567.455);
   }
 
   @Test(expected = SpinJsonDataFormatException.class)
@@ -260,7 +260,7 @@ public abstract class JsonTreeReadPropertyScriptTest extends ScriptTest {
     assertThat(property2).isNotNull();
 
     // Ruby casts this to long instead int
-    assertThat(value1.intValue()).isEqualTo(32000);
+    assertThat(value1.longValue()).isEqualTo(1234567L);
     assertThat(value2).isEqualTo("dollar");
   }
 

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/groovy/json/tree/JsonTreeJsonPathGroovyTest.shouldGetNumberFromJsonPath.groovy
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/groovy/json/tree/JsonTreeJsonPathGroovyTest.shouldGetNumberFromJsonPath.groovy
@@ -2,4 +2,4 @@ package org.camunda.spin.groovy.json.tree
 
 jsonNode = S(input, "application/json");
 
-numberValue = jsonNode.jsonPath('$.id').numberValue();
+numberValue = jsonNode.jsonPath('$.orderDetails.price').numberValue();

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/groovy/json/tree/JsonTreeMapObjectToJsonGroovyTest.shouldMapDictionary.groovy
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/groovy/json/tree/JsonTreeMapObjectToJsonGroovyTest.shouldMapDictionary.groovy
@@ -7,7 +7,7 @@ order = ["order" : "order1", "dueUntil": 20150112, "id": 1234567890987654321, "a
 customers = [customer("Kermit", 1354539722), customer("Waldo", 1320325322), customer("Johnny", 1286110922)]
 order["customers"] = customers
 
-orderDetails = ["article": "camundaBPM", "price": 32000.45, "roundedPrice": 32000, "currencies": ["euro", "dollar"], "paid": false]
+orderDetails = ["article": "camundaBPM", "price": 1234567.455, "roundedPrice": 1234567, "currencies": ["euro", "dollar"], "paid": false]
 order["orderDetails"] = orderDetails
 
 json = S(order, "application/json").toString()

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/javascript/json/tree/JsonTreeJsonPathJavascriptTest.shouldGetNumberFromJsonPath.js
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/javascript/json/tree/JsonTreeJsonPathJavascriptTest.shouldGetNumberFromJsonPath.js
@@ -1,3 +1,3 @@
 var jsonNode = S(input, "application/json");
 
-numberValue = jsonNode.jsonPath('$.id').numberValue();
+numberValue = jsonNode.jsonPath('$.orderDetails.price').numberValue();

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/javascript/nashorn/json/tree/JsonTreeJsonPathJavascriptTest.shouldGetNumberFromJsonPath.js
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/javascript/nashorn/json/tree/JsonTreeJsonPathJavascriptTest.shouldGetNumberFromJsonPath.js
@@ -1,3 +1,3 @@
 var jsonNode = S(input, "application/json");
 
-numberValue = jsonNode.jsonPath('$.id').numberValue();
+numberValue = jsonNode.jsonPath('$.orderDetails.price').numberValue();

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/json/example.json
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/json/example.json
@@ -18,8 +18,8 @@
   ],
   "orderDetails": {
     "article": "camundaBPM",
-    "price": 32000.45,
-    "roundedPrice": 32000,
+    "price": 1234567.455,
+    "roundedPrice": 1234567,
     "currencies": [
       "euro",
       "dollar"

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/python/json/tree/JsonTreeJsonPathPythonTest.shouldGetNumberFromJsonPath.py
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/python/json/tree/JsonTreeJsonPathPythonTest.shouldGetNumberFromJsonPath.py
@@ -1,3 +1,3 @@
 jsonNode = S(input, "application/json")
 
-numberValue = jsonNode.jsonPath('$.id').numberValue()
+numberValue = jsonNode.jsonPath('$.orderDetails.price').numberValue()

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/python/json/tree/JsonTreeMapObjectToJsonPythonTest.shouldMapDictionary.py
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/python/json/tree/JsonTreeMapObjectToJsonPythonTest.shouldMapDictionary.py
@@ -6,7 +6,7 @@ order = {"order" : "order1", "dueUntil": 20150112, "id": 1234567890987654321, "a
 customers = [customer("Kermit", 1354539722), customer("Waldo", 1320325322), customer("Johnny", 1286110922)]
 order["customers"] = customers
 
-orderDetails = {"article": "camundaBPM", "price": 32000.45, "roundedPrice": 32000, "currencies": ["euro", "dollar"], "paid": False}
+orderDetails = {"article": "camundaBPM", "price": 1234567.455, "roundedPrice": 1234567, "currencies": ["euro", "dollar"], "paid": False}
 order["orderDetails"] = orderDetails
 
 json = S(order, "application/json").toString()

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/ruby/json/tree/JsonTreeJsonPathRubyTest.shouldGetNumberFromJsonPath.rb
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/ruby/json/tree/JsonTreeJsonPathRubyTest.shouldGetNumberFromJsonPath.rb
@@ -1,3 +1,3 @@
 jsonNode = S($input, "application/json")
 
-$numberValue = jsonNode.jsonPath('$.id').numberValue()
+$numberValue = jsonNode.jsonPath('$.orderDetails.price').numberValue()

--- a/dataformat-json-jackson/src/test/resources/org/camunda/spin/ruby/json/tree/JsonTreeMapObjectToJsonRubyTest.shouldMapDictionary.rb
+++ b/dataformat-json-jackson/src/test/resources/org/camunda/spin/ruby/json/tree/JsonTreeMapObjectToJsonRubyTest.shouldMapDictionary.rb
@@ -7,7 +7,7 @@ order = {"order" => "order1", "dueUntil" => 20150112, "id" => 123456789098765432
 customers = [customer("Kermit", 1354539722), customer("Waldo", 1320325322), customer("Johnny", 1286110922)]
 order["customers"] = customers
 
-orderDetails = {"article" => "camundaBPM", "price" => 32000.45, "roundedPrice" => 32000, "currencies" => ["euro", "dollar"], "paid" => false}
+orderDetails = {"article" => "camundaBPM", "price" => 1234567.455, "roundedPrice" => 1234567, "currencies" => ["euro", "dollar"], "paid" => false}
 order["orderDetails"] = orderDetails
 
 $json = S(order, "application/json").toString()


### PR DESCRIPTION
* uses Double as default data type for Number nodes instead
  of Float as it provides higher precision and is consistent
  with Jackson's behavior for Number nodes (so "prop" and
  "jsonPath" methods are more consistent in behavior)