### PR TITLE
Fix the documentation for SpinJsonNode.lastIndexOf() (it actually throws if element is not present) and implement a contains-method to support common use-case

### DIFF
--- a/core/src/main/java/org/camunda/spin/json/SpinJsonNode.java
+++ b/core/src/main/java/org/camunda/spin/json/SpinJsonNode.java
@@ -45,10 +45,21 @@ public abstract class SpinJsonNode extends Spin<SpinJsonNode> {
    * Fetches the last index of the searched object in an array.
    *
    * @param searchObject Object for which the index should be searched.
-   * @return {@link Integer} index of searchObject or -1 if object not found.
+   * @return {@link Integer} index of searchObject.
    * @throws SpinJsonException if the current node is not an array.
+   * @throws SpinJsonPropertyException if object is not found.
    */
   public abstract Integer lastIndexOf(Object searchObject);
+
+  /**
+   * Fetches the last index of the searched object in an array.
+   *
+   * @param searchObject Object for which the index should be searched.
+   * @return {@link Integer} index of searchObject.
+   * @throws SpinJsonException if the current node is not an array.
+   * @throws SpinJsonPropertyException if object is not found.
+   */
+  public abstract boolean contains(Object searchObject);
 
   /**
    * Check if this node is an object node.

--- a/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/JacksonJsonNode.java
+++ b/dataformat-json-jackson/src/main/java/org/camunda/spin/impl/json/jackson/JacksonJsonNode.java
@@ -154,6 +154,24 @@ public class JacksonJsonNode extends SpinJsonNode {
     }
   }
 
+  public boolean contains(Object searchObject) {
+    ensureNotNull("searchObject", searchObject);
+    if(this.isArray()) {
+      JsonNode node = dataFormat.createJsonNode(searchObject);
+      for (Iterator<JsonNode> nodeIterator = jsonNode.elements(); nodeIterator.hasNext();) {
+        JsonNode n = nodeIterator.next();
+        if (n.equals(node)) {
+          return true;
+        }
+      }
+
+      // when searchObject is not found
+      return false;
+    } else {
+      throw LOG.unableToGetIndex(jsonNode.getNodeType().name());
+    }
+  }
+
   public boolean isObject() {
     return jsonNode.isObject();
   }

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/impl/json/jackson/JacksonJsonNodeTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/impl/json/jackson/JacksonJsonNodeTest.java
@@ -1,0 +1,17 @@
+package org.camunda.spin.impl.json.jackson;
+
+import org.camunda.spin.Spin;
+import org.camunda.spin.json.SpinJsonNode;
+
+import junit.framework.TestCase;
+
+public class JacksonJsonNodeTest extends TestCase {
+	public void testName() {
+		SpinJsonNode node = Spin.JSON("[\"foo\", \"bar\", \"\\\"foo\\\"\"]");
+		System.out.println(node.toString());
+		SpinJsonNode node1 = node.elements().get(1);
+		System.out.println(node.equals("foo"));
+		System.out.println(node.hasProp("foo"));
+		//System.out.println(node.lastIndexOf("baz"));
+	}
+}

--- a/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeEditListPropertyTest.java
+++ b/dataformat-json-jackson/src/test/java/org/camunda/spin/json/tree/JsonTreeEditListPropertyTest.java
@@ -599,4 +599,40 @@ public class JsonTreeEditListPropertyTest {
       // expected
     }
   }
+
+  // ----------------- 10) contains ----------------------
+
+  @Test
+  public void containsOfNonArray() {
+    try {
+      jsonNode.contains("n");
+      fail("Expected: SpinJsonTreeNodeException");
+    } catch(SpinJsonException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void containsWithoutSearchNode() {
+    try {
+      jsonNode.contains(null);
+      fail("Expected: IllegalArgumentException");
+    } catch(IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void containsNonExistentValue() {
+    boolean res = customers.contains("n");
+
+    assertThat(res).isFalse();
+  }
+
+  @Test
+  public void containsOfExistentValue() {
+    boolean res = currencies.contains("euro");
+
+    assertThat(res).isTrue();
+  }
 }


### PR DESCRIPTION
Fix the documentation for SpinJsonNode.lastIndexOf() and implement a contains-method.

This is a fix for #134.