### PR TITLE
chore(*): bump Jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <commons.version>1.10.0</commons.version>
     <graal.js.version>21.1.0</graal.js.version>
     <groovy.version>2.4.13</groovy.version>
-    <jackson.version>2.13.1</jackson.version>
+    <jackson.version>2.13.2.20220328</jackson.version>
     <jaxb-impl.version>2.3.6</jaxb-impl.version>
     <jruby.version>9.1.17.0</jruby.version>
     <json-junit-fluent.version>1.1.6</json-junit-fluent.version>
@@ -52,6 +52,14 @@
         <version>${commons.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>
@@ -112,18 +120,6 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
* uses the Jackson BOM instead of single artifact versions
* uses the Jackson BOM 2.13.2.20220328

related to CAM-14504