### PR TITLE
CAM-14806: fix test execution on IBM JDK

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -7,6 +7,10 @@ buildMavenAndDeployToMavenCentral([
   publishZipArtifactToCamundaOrg:true,
   extraJdks: [
    'jdk-11-latest',
-   'jdk-17-latest'
+   'jdk-17-latest',
+   'openjdk-jdk-8-latest',
+   'openjdk-jdk-11-latest',
+   'openjdk-jdk-17-latest',
+   'ibm-jdk-8-latest'
   ]
 ])

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
@@ -28,6 +28,7 @@ import java.io.UnsupportedEncodingException;
 import org.camunda.spin.DataFormats;
 import org.camunda.spin.SpinFactory;
 import org.camunda.spin.spi.DataFormat;
+import org.camunda.spin.xml.JdkUtil;
 import org.camunda.spin.xml.SpinXmlElement;
 import org.junit.Test;
 
@@ -39,10 +40,13 @@ public class DomXmlDataFormatWriterTest {
   private final String newLine = System.getProperty("line.separator");
   private final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><order><product>Milk</product><product>Coffee</product></order>";
 
-  private final String formattedXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><order>" + newLine
+
+  private final String formattedXmlIbmJDK = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><order>" + newLine
       + "  <product>Milk</product>" + newLine
       + "  <product>Coffee</product>" + newLine
-      + "</order>" + newLine;
+      + "</order>";
+
+  private final String formattedXml = formattedXmlIbmJDK + newLine;
 
 
   // this is what execution.setVariable("test", spinXml); does
@@ -67,6 +71,18 @@ public class DomXmlDataFormatWriterTest {
   }
 
   /**
+   * IBM JDK does not generate a new line character at the end
+   * of an XSLT-transformed XML document. See CAM-14806.
+   */
+  private String getExpectedFormattedXML() {
+    if (JdkUtil.runsOnIbmJDK()) {
+      return formattedXmlIbmJDK;
+    } else {
+      return formattedXml;
+    }
+  }
+
+  /**
    * standard behaviour: an unformatted XML will be formatted stored into a SPIN variable and also returned formatted.
    */
   @Test
@@ -81,14 +97,14 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that there are now new lines in the serialized value:
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(formattedXml);
+    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(getExpectedFormattedXML());
 
     // when
     // this is what execution.getVariable("test"); does
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(formattedXml);
+    assertThat(spinXmlElement.toString()).isEqualTo(getExpectedFormattedXML());
   }
 
   /**
@@ -107,14 +123,14 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that there are no new lines in the serialized value:
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(formattedXml);
+    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(getExpectedFormattedXML());
 
     // when
     // this is what execution.getVariable("test"); does
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(formattedXml);
+    assertThat(spinXmlElement.toString()).isEqualTo(getExpectedFormattedXML());
   }
 
   /**

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/JdkUtil.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/JdkUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.xml;
+
+public class JdkUtil {
+
+  public static boolean runsOnIbmJDK() {
+    String vendor = System.getProperty("java.vm.vendor");
+
+    if (vendor == null) {
+      return false;
+    } else {
+      return vendor.contains("IBM");
+    }
+  }
+}

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/format/spi/DomXmlDataFormatProtectionTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/format/spi/DomXmlDataFormatProtectionTest.java
@@ -23,7 +23,9 @@ import java.io.InputStreamReader;
 
 import org.camunda.spin.DataFormats;
 import org.camunda.spin.impl.xml.dom.format.DomXmlDataFormat;
+import org.camunda.spin.xml.JdkUtil;
 import org.camunda.spin.xml.SpinXmlDataFormatException;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -38,6 +40,9 @@ public class DomXmlDataFormatProtectionTest {
 
   @Test
   public void shouldThrowExceptionForTooManyAttributes() {
+    // IBM JDKs do not check on attribute number limits, skip the test there
+    Assume.assumeFalse(JdkUtil.runsOnIbmJDK());
+
     // given
     String testXml = "org/camunda/spin/xml/dom/format/spi/FeatureSecureProcessing.xml";
     InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);


### PR DESCRIPTION
- DomXmlDataFormatWriterTest: IBM JDK does not generate a new line character
  at the end of an XSLT-transformed output
- DomXmlDataFormatProtectionTest: IBM JDK does not implement an attribute
  limit when secure XML processing is activated

related to CAM-14806