### PR TITLE
chore(project): fix Javadoc plugin for release

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -63,7 +63,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>${plugin.version.javadoc}</version>
           <configuration combine.children="append">
             <doclint>none</doclint>
             <detectJavaApiLink>false</detectJavaApiLink>
@@ -72,6 +72,25 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>sonatype-oss-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${plugin.version.javadoc}</version>
+            <configuration combine.children="append">
+              <doclint>none</doclint>
+              <detectJavaApiLink>false</detectJavaApiLink>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <scm>
     <url>https://github.com/camunda/camunda-spin</url>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -77,25 +77,6 @@
     </pluginManagement>
   </build>
 
-  <profiles>
-    <profile>
-      <id>sonatype-oss-release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${plugin.version.javadoc}</version>
-            <configuration combine.children="append">
-              <doclint>none</doclint>
-              <detectJavaApiLink>false</detectJavaApiLink>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <scm>
     <url>https://github.com/camunda/camunda-spin</url>
     <connection>scm:git:git@github.com:camunda/camunda-spin.git</connection>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -15,6 +15,10 @@
   <name>camunda spin - bom</name>
   <packaging>pom</packaging>
 
+  <properties>
+    <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
     <spin.version.old>1.18.0</spin.version.old>
     <xml.bind-api.version>2.3.3</xml.bind-api.version>
 
-    <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
-
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
     <spin.version.old>1.18.0</spin.version.old>
     <xml.bind-api.version>2.3.3</xml.bind-api.version>
 
+    <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
+
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>


### PR DESCRIPTION
* Fixes the Javadoc plugin version and configuration for releases with JDK 11
* Closes https://github.com/camunda/camunda-bpm-platform/issues/3244