### PR TITLE
feat(xml): support custom formatting configuration

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -7,6 +7,10 @@ buildMavenAndDeployToMavenCentral([
   publishZipArtifactToCamundaOrg:true,
   extraJdks: [
    'jdk-11-latest',
-   'jdk-17-latest'
+   'jdk-17-latest',
+   'openjdk-jdk-8-latest',
+   'openjdk-jdk-11-latest',
+   'openjdk-jdk-17-latest',
+   'ibm-jdk-8-latest'
   ]
 ])

--- a/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/DomXmlLogger.java
+++ b/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/DomXmlLogger.java
@@ -17,7 +17,6 @@
 package org.camunda.spin.impl.xml.dom;
 
 import java.util.NoSuchElementException;
-
 import org.camunda.commons.logging.BaseLogger;
 import org.camunda.spin.impl.logging.SpinLogger;
 import org.camunda.spin.xml.SpinXPathException;
@@ -189,7 +188,7 @@ public class DomXmlLogger extends SpinLogger {
   }
 
   public SpinXmlDataFormatException unableToFindStripSpaceXsl(String expression) {
-    return new SpinXmlDataFormatException(exceptionMessage("037", "Unable to find strip-space.xsl '{}'", expression));
+    return new SpinXmlDataFormatException(exceptionMessage("037", "No formatting configuration defined and unable to find the default '{}'", expression));
   }
 
   public SpinXmlDataFormatException unableToLoadFormattingTemplates(Throwable cause) {

--- a/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/format/DomXmlDataFormat.java
+++ b/dataformat-xml-dom/src/main/java/org/camunda/spin/impl/xml/dom/format/DomXmlDataFormat.java
@@ -16,14 +16,13 @@
  */
 package org.camunda.spin.impl.xml.dom.format;
 
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerFactory;
-
-import java.util.Collections;
-import java.util.Map;
-
 import org.camunda.spin.impl.xml.dom.DomXmlAttribute;
 import org.camunda.spin.impl.xml.dom.DomXmlElement;
 import org.camunda.spin.impl.xml.dom.DomXmlLogger;
@@ -37,7 +36,6 @@ import org.w3c.dom.Element;
 
 /**
  * @author Daniel Meyer
- *
  */
 public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
 
@@ -54,13 +52,19 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
   public static final String XXE_PROPERTY = "xxe-processing";
   public static final String SP_PROPERTY = "secure-processing";
 
-  /** the DocumentBuilderFactory used by the reader */
+  /**
+   * the DocumentBuilderFactory used by the reader
+   */
   protected DocumentBuilderFactory documentBuilderFactory;
 
-  /** the TransformerFactory instance used by the writer */
+  /**
+   * the TransformerFactory instance used by the writer
+   */
   protected TransformerFactory transformerFactory;
 
-  /** the JaxBContextProvider instance used by this writer. */
+  /**
+   * the JaxBContextProvider instance used by this writer.
+   */
   protected JaxBContextProvider jaxBContextProvider;
 
   protected DomXmlDataFormatReader reader;
@@ -70,6 +74,8 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
   protected final String name;
 
   protected boolean prettyPrint;
+
+  protected InputStream formattingConfiguration;
 
   public DomXmlDataFormat(String name) {
     this(name, defaultDocumentBuilderFactory());
@@ -100,6 +106,7 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
     this.name = name;
     this.documentBuilderFactory = documentBuilderFactory;
     this.prettyPrint = true;
+    this.formattingConfiguration = null;
 
     LOG.usingDocumentBuilderFactory(documentBuilderFactory.getClass().getName());
 
@@ -115,14 +122,17 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
     this.mapper = new DomXmlDataFormatMapper(this);
   }
 
+  @Override
   public Class<? extends SpinXmlElement> getWrapperType() {
     return DomXmlElement.class;
   }
 
+  @Override
   public SpinXmlElement createWrapperInstance(Object parameter) {
     return createElementWrapper((Element) parameter);
   }
 
+  @Override
   public String getName() {
     return name;
   }
@@ -135,14 +145,17 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
     return new DomXmlAttribute(attr, this);
   }
 
+  @Override
   public DomXmlDataFormatReader getReader() {
     return reader;
   }
 
+  @Override
   public DomXmlDataFormatWriter getWriter() {
     return writer;
   }
 
+  @Override
   public DomXmlDataFormatMapper getMapper() {
     return mapper;
   }
@@ -180,6 +193,16 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
     this.prettyPrint = prettyPrint;
   }
 
+  public InputStream getFormattingConfiguration() {
+    return this.formattingConfiguration;
+  }
+
+  public void setFormattingConfiguration(InputStream formattingConfiguration) {
+    this.formattingConfiguration = formattingConfiguration;
+    //writer need a new formattingTemplate with the new formattingConfiguration
+    this.writer.setFormattingTemplates(this.writer.reloadFormattingTemplates());
+  }
+
   public static TransformerFactory defaultTransformerFactory() {
     return TransformerFactory.newInstance();
   }
@@ -188,8 +211,7 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
     return configurableDocumentBuilderFactory(Collections.emptyMap());
   }
 
-  public static DocumentBuilderFactory configurableDocumentBuilderFactory(
-      Map<String,Object> configurationProperties) {
+  public static DocumentBuilderFactory configurableDocumentBuilderFactory(Map<String, Object> configurationProperties) {
 
     DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
@@ -28,6 +28,7 @@ import java.io.UnsupportedEncodingException;
 import org.camunda.spin.DataFormats;
 import org.camunda.spin.SpinFactory;
 import org.camunda.spin.spi.DataFormat;
+import org.camunda.spin.xml.JdkUtil;
 import org.camunda.spin.xml.SpinXmlElement;
 import org.junit.Test;
 
@@ -39,10 +40,13 @@ public class DomXmlDataFormatWriterTest {
   private final String newLine = System.getProperty("line.separator");
   private final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><order><product>Milk</product><product>Coffee</product></order>";
 
-  private final String formattedXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><order>" + newLine
+
+  private final String formattedXmlIbmJDK = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><order>" + newLine
       + "  <product>Milk</product>" + newLine
       + "  <product>Coffee</product>" + newLine
-      + "</order>" + newLine;
+      + "</order>";
+
+  private final String formattedXml = formattedXmlIbmJDK + newLine;
 
 
   // this is what execution.setVariable("test", spinXml); does
@@ -67,6 +71,18 @@ public class DomXmlDataFormatWriterTest {
   }
 
   /**
+   * IBM JDK does not generate a new line character at the end
+   * of an XSLT-transformed XML document. See CAM-14806.
+   */
+  private String getExpectedFormattedXML() {
+    if (JdkUtil.runsOnIbmJDK()) {
+      return formattedXmlIbmJDK;
+    } else {
+      return formattedXml;
+    }
+  }
+
+  /**
    * standard behaviour: an unformatted XML will be formatted stored into a SPIN variable and also returned formatted.
    */
   @Test
@@ -81,14 +97,14 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that there are now new lines in the serialized value:
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(formattedXml);
+    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(getExpectedFormattedXML());
 
     // when
     // this is what execution.getVariable("test"); does
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(formattedXml);
+    assertThat(spinXmlElement.toString()).isEqualTo(getExpectedFormattedXML());
   }
 
   /**
@@ -107,14 +123,14 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that there are no new lines in the serialized value:
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(formattedXml);
+    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(getExpectedFormattedXML());
 
     // when
     // this is what execution.getVariable("test"); does
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(formattedXml);
+    assertThat(spinXmlElement.toString()).isEqualTo(getExpectedFormattedXML());
   }
 
   /**

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/JdkUtil.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/JdkUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.xml;
+
+public class JdkUtil {
+
+  public static boolean runsOnIbmJDK() {
+    String vendor = System.getProperty("java.vm.vendor");
+
+    if (vendor == null) {
+      return false;
+    } else {
+      return vendor.contains("IBM");
+    }
+  }
+}

--- a/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/format/spi/DomXmlDataFormatProtectionTest.java
+++ b/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/format/spi/DomXmlDataFormatProtectionTest.java
@@ -23,7 +23,9 @@ import java.io.InputStreamReader;
 
 import org.camunda.spin.DataFormats;
 import org.camunda.spin.impl.xml.dom.format.DomXmlDataFormat;
+import org.camunda.spin.xml.JdkUtil;
 import org.camunda.spin.xml.SpinXmlDataFormatException;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -38,6 +40,9 @@ public class DomXmlDataFormatProtectionTest {
 
   @Test
   public void shouldThrowExceptionForTooManyAttributes() {
+    // IBM JDKs do not check on attribute number limits, skip the test there
+    Assume.assumeFalse(JdkUtil.runsOnIbmJDK());
+
     // given
     String testXml = "org/camunda/spin/xml/dom/format/spi/FeatureSecureProcessing.xml";
     InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);

--- a/dataformat-xml-dom/src/test/resources/org/camunda/spin/strip-space-preserve-space.xsl
+++ b/dataformat-xml-dom/src/test/resources/org/camunda/spin/strip-space-preserve-space.xsl
@@ -1,0 +1,16 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output method="xml"/>
+
+    <xsl:strip-space elements="*"/>
+
+    <xsl:preserve-space elements="product"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
* Backports IBM JDK compatibility
* Supports writing a custom `DataFormatConfigurator` to configure the XSLT file
  in `DomXmlDataFormat` which will be used in `DomXmlDataFormatWriter` when
  `prettyPrint` is enabled.

related to CAM-14806, https://github.com/camunda/camunda-bpm-platform/issues/3633