### PR TITLE
chore(pom): adjust snapshot versions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.camunda.spin</groupId>
   <artifactId>camunda-spin-bom</artifactId>
-  <version>1.24.0-SNAPSHOT</version>
+  <version>1.23.1-SNAPSHOT</version>
   <name>camunda spin - bom</name>
   <packaging>pom</packaging>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda.spin</groupId>
     <artifactId>camunda-spin-root</artifactId>
-    <version>1.24.0-SNAPSHOT</version>
+    <version>1.23.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-spin-core</artifactId>

--- a/dataformat-all/pom.xml
+++ b/dataformat-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda.spin</groupId>
     <artifactId>camunda-spin-root</artifactId>
-    <version>1.24.0-SNAPSHOT</version>
+    <version>1.23.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-spin-dataformat-all</artifactId>

--- a/dataformat-json-jackson/pom.xml
+++ b/dataformat-json-jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda.spin</groupId>
     <artifactId>camunda-spin-root</artifactId>
-    <version>1.24.0-SNAPSHOT</version>
+    <version>1.23.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-spin-dataformat-json-jackson</artifactId>

--- a/dataformat-xml-dom-jakarta/pom.xml
+++ b/dataformat-xml-dom-jakarta/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda.spin</groupId>
     <artifactId>camunda-spin-root</artifactId>
-    <version>1.24.0-SNAPSHOT</version>
+    <version>1.23.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-spin-dataformat-xml-dom-jakarta</artifactId>

--- a/dataformat-xml-dom/pom.xml
+++ b/dataformat-xml-dom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda.spin</groupId>
     <artifactId>camunda-spin-root</artifactId>
-    <version>1.24.0-SNAPSHOT</version>
+    <version>1.23.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-spin-dataformat-xml-dom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda.spin</groupId>
     <artifactId>camunda-spin-bom</artifactId>
-    <version>1.24.0-SNAPSHOT</version>
+    <version>1.23.1-SNAPSHOT</version>
     <relativePath>bom</relativePath>
   </parent>
 


### PR DESCRIPTION
add 1.23 branch and make 1.23.1-snapshot current development version
https://github.com/camunda/team-automation-platform/issues/195