### PR TITLE
chore: switch to Sonatype Central Portal deployment (1.22)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.5.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

Backporting https://github.com/camunda/camunda-spin/pull/224 to `1.22` branch.