### PR TITLE
chore: switch to Sonatype Central Portal deployment (1.19)

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -4,6 +4,7 @@ buildMavenAndDeployToMavenCentral([
   mvn:3.5,
   additionalMvnGoals:'javadoc:javadoc',
   licenseCheck:true,
+  mvnReleaseProfiles:'sonatype-oss-release',
   publishZipArtifactToCamundaOrg:true,
   extraJdks: [
    'jdk-8-latest',

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.2.6</version>
+    <version>2.2.8</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

Backporting https://github.com/camunda/camunda-spin/pull/224 to `1.19` branch.

Use the deprecated sonatype-oss-release profile as a fallback (central-publishing-maven-plugin may not work with Maven < 3.8)